### PR TITLE
Feat: remove `strictLimit`

### DIFF
--- a/src/paginate.ts
+++ b/src/paginate.ts
@@ -85,7 +85,7 @@ export class Paginate<Model extends PrismaClientModel> {
         ? this.paginationArgs.pageIndex + 1
         : 1;
     const hasNextPage = page < totalPages;
-    const hasPrevPage = count > 0 && page > 1;
+    const hasPrevPage = count > 0 && page > 1 && page <= totalPages + 1;
     const pagination: Required<Pagination<Model>> = {
       ...this.nextPage(),
       limit: this.paginationArgs.limit,

--- a/src/paginate.ts
+++ b/src/paginate.ts
@@ -74,13 +74,8 @@ export class Paginate<Model extends PrismaClientModel> {
     count: number,
     findManyReturn: PrismaFindManyReturn<Model>
   ): Required<PaginationResult<Model>> {
-    const strictLimit = (count / this.paginationArgs.limit).toFixed(1);
-    const totalPages =
-      this.paginationArgs.strictLimit === true
-        ? Number(strictLimit[strictLimit.length - 1]) > 0
-          ? Math.round(Number(strictLimit)) - 1
-          : Math.round(Number(strictLimit))
-        : Math.round(count / this.paginationArgs.limit);
+    const totalPages = Math.ceil(count / this.paginationArgs.limit);
+
     const page =
       typeof this.paginationArgs.page === "number"
         ? this.paginationArgs.page === 0
@@ -90,17 +85,12 @@ export class Paginate<Model extends PrismaClientModel> {
         ? this.paginationArgs.pageIndex + 1
         : 1;
     const hasNextPage = page < totalPages;
-    const hasPrevPage =
-      count > 0 && page > 1
-        ? (page * this.paginationArgs.limit) / count - 1 === 0 ||
-          page - 1 === totalPages
-        : false;
+    const hasPrevPage = count > 0 && page > 1;
     const pagination: Required<Pagination<Model>> = {
       ...this.nextPage(),
       limit: this.paginationArgs.limit,
       exceedCount: this.paginationArgs.exceedCount === true,
       exceedTotalPages: this.paginationArgs.exceedTotalPages === true,
-      strictLimit: this.paginationArgs.strictLimit === true,
       count,
       totalPages,
       hasNextPage,

--- a/src/paginator.ts
+++ b/src/paginator.ts
@@ -160,22 +160,6 @@ export namespace paginator {
      * @see {@link ExceedTotalPages}
      */
     exceedTotalPages: boolean;
-    /**
-     * @example
-     * // on database = [ { id: 1 }, { id: 2 }, {...}, { id: 6 } ]
-     * paginator(client).myTable.paginate({ where: {} },
-     *    { limit: 5, page: 1, strictLimit: true })
-     *   .then((result) => {
-     *     // if strictLimit: true
-     *     console.log(result.totalPage) // 1
-     *     console.log(result.hasNextPage) // false
-     *     // else
-     *     console.log(result.totalPage) // 2
-     *     console.log(result.hasNextPage) // true
-     *   })
-     * @default false
-     */
-    strictLimit: boolean;
   }
 
   export interface Pagination<Model extends PrismaClientModel = any>

--- a/test/paginator.test.ts
+++ b/test/paginator.test.ts
@@ -91,7 +91,7 @@ describe("random array", () => {
           expect(result.result).toStrictEqual([]);
           expect(result.count).toBe(randomIds.length);
           expect(result.hasNextPage).toBe(false);
-          expect(result.hasPrevPage).toBe(true);
+          expect(result.hasPrevPage).toBe(false);
           expect(result.limit).toBe(1);
           expect(result.page).toBe(randomIds.length + 2);
           expect(result.totalPages).toBe(randomIds.length);

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -64,11 +64,5 @@ export const randomArray = createRandomArray();
 export const randomIds = randomArray.map((id) => ({ id }));
 
 export function createRandomArray() {
-  return [
-    ...new Set(
-      Array.from({ length: 100 }, () =>
-        Number((Math.random() * 100).toFixed(0))
-      )
-    ),
-  ].sort((asc, desc) => asc - desc);
+  return Array.from({ length: 100 }, (_, i) => i);
 }


### PR DESCRIPTION
- Stop using random numbers in tests, it mean that often the `randomIds` was only ~60 items in length. Just uses incrementing numbers now
- Now wipes the entire database table both before and after all the tests run to ensure a clean slate and old test data isnt left over.
- Removes `strictLimit` - this was just a hacky workaround because total pages wasnt being calculated correctly.
- Fixes a bug where `hasNextPage` was incorrect, the logic for this was overly complex - it didn't need to be.

Closes #32.

